### PR TITLE
[stable-kiam] Add ability to provide TLS keys via predefined secrets

### DIFF
--- a/stable/kiam/README.md
+++ b/stable/kiam/README.md
@@ -43,6 +43,19 @@ server:
     ca: LS0tL...
 ```
 
+Alternately, you can create the TLS files and add them to kubernetes secrets yourself as explained [here](https://github.com/uswitch/kiam/blob/master/docs/TLS.md).
+If you do so, specify the secret names in your chart values:
+
+```yaml
+agent:
+  useProvidedTlsSecret: true
+  tlsSecretName: agent-secret-name-you-defined
+
+server:
+  useProvidedTlsSecret: true
+  tlsSecretName: server-secret-name-you-defined
+```
+
 To install the chart with the release name `my-release`:
 
 ```console
@@ -93,8 +106,10 @@ Parameter | Description | Default
 `agent.tlsFiles.ca` | Base64 encoded string for the agent's CA certificate(s) | `null`
 `agent.tlsFiles.cert` | Base64 encoded strings for the agent's certificate | `null`
 `agent.tlsFiles.key` | Base64 encoded strings for the agent's private key | `null`
+`agent.tlsSecretName` | The name of the predefined secret when using `agent.useProvidedTlsSecret` | `null`
 `agent.tolerations` | Tolerations to be applied to agent pods | `[]`
 `agent.updateStrategy` | Strategy for agent DaemonSet updates (requires Kubernetes 1.6+) | `OnDelete`
+`agent.useProvidedTlsSecret` | Use a predefined secret that you created with the TLS files | `false`
 `server.enabled` | If true, create server | `true`
 `server.name` | Server container name | `server`
 `server.gatewayTimeoutCreation` | Server's timeout when creating the kiam gateway | `50ms`
@@ -123,9 +138,11 @@ Parameter | Description | Default
 `server.tlsFiles.ca` | Base64 encoded string for the server's CA certificate(s) | `null`
 `server.tlsFiles.cert` | Base64 encoded strings for the server's certificate | `null`
 `server.tlsFiles.key` | Base64 encoded strings for the server's private key | `null`
+`server.tlsSecretName` | The name of the predefined secret when using `server.useProvidedTlsSecret` | `null`
 `server.tolerations` | Tolerations to be applied to server pods | `[]`
 `server.updateStrategy` | Strategy for server DaemonSet updates (requires Kubernetes 1.6+) | `OnDelete`
 `server.useHostNetwork` | If true, use hostNetwork on server to bypass agent iptable rules | `false`
+`server.useProvidedTlsSecret` | Use a predefined secret that you created with the TLS files | `false`
 `rbac.create` | If `true`, create & use RBAC resources | `true`
 `serviceAccounts.agent.create` | If true, create the agent service account | `true`
 `serviceAccounts.agent.name` | Name of the agent service account to use or create | `{{ kiam.agent.fullname }}`

--- a/stable/kiam/templates/_helpers.tpl
+++ b/stable/kiam/templates/_helpers.tpl
@@ -88,3 +88,26 @@ Create the name of the server service account to use.
     {{ default "default" .Values.serviceAccounts.server.name }}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Define the name of the server secret that contains our tls files.
+*/}}
+{{- define "kiam.server.secretName" -}}
+{{- if .Values.server.useProvidedTlsSecret -}}
+{{- .Values.server.tlsSecretName -}}
+{{- else -}}
+{{- printf "%s-server" (include "kiam.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define the name of the agent secret that contains our tls files.
+*/}}
+{{- define "kiam.agent.secretName" -}}
+{{- if .Values.agent.useProvidedTlsSecret -}}
+{{- .Values.agent.tlsSecretName -}}
+{{- else -}}
+{{- printf "%s-agent" (include "kiam.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/stable/kiam/templates/agent-daemonset.yaml
+++ b/stable/kiam/templates/agent-daemonset.yaml
@@ -44,7 +44,7 @@ spec:
       volumes:
         - name: tls
           secret:
-            secretName: {{ template "kiam.fullname" . }}-agent
+            secretName: {{ template "kiam.server.secretName" . }}
         - name: xtables
           hostPath:
             path: /run/xtables.lock

--- a/stable/kiam/templates/agent-secret.yaml
+++ b/stable/kiam/templates/agent-secret.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.agent.enabled -}}
+{{- if not .Values.server.useProvidedTlsSecret -}}
 kind: Secret
 apiVersion: v1
 metadata:
@@ -6,4 +7,5 @@ metadata:
 type: Opaque
 data:
 {{ toYaml .Values.agent.tlsFiles | indent 2 }}
+{{- end }}
 {{- end }}

--- a/stable/kiam/templates/server-daemonset.yaml
+++ b/stable/kiam/templates/server-daemonset.yaml
@@ -40,7 +40,7 @@ spec:
       volumes:
         - name: tls
           secret:
-            secretName: {{ template "kiam.fullname" . }}-server
+            secretName: {{ template "kiam.server.secretName" . }}
       {{- range .Values.server.extraHostPathMounts }}
         - name: {{ .name }}
           hostPath:

--- a/stable/kiam/templates/server-secret.yaml
+++ b/stable/kiam/templates/server-secret.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.server.enabled -}}
+{{- if not .Values.server.useProvidedTlsSecret -}}
 kind: Secret
 apiVersion: v1
 metadata:
@@ -6,4 +7,5 @@ metadata:
 type: Opaque
 data:
 {{ toYaml .Values.server.tlsFiles | indent 2 }}
+{{- end }}
 {{- end }}

--- a/stable/kiam/values.yaml
+++ b/stable/kiam/values.yaml
@@ -87,6 +87,10 @@ agent:
     cert:
     key:
 
+  # Use an existing k8s secret to retrieve the TLS files
+  useProvidedTlsSecret: false
+  tlsSecretName: null
+
 server:
   ## If false, server will not be installed
   ##
@@ -168,6 +172,10 @@ server:
     ca:
     cert:
     key:
+
+  # Use an existing k8s secret to retrieve the TLS files
+  useProvidedTlsSecret: false
+  tlsSecretName: null
 
   ## Base ARN for IAM roles
   ## If not specified use EC2 metadata service to detect ARN prefix


### PR DESCRIPTION

<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Add ability to provide TLS keys via predefined secrets instead of generating the secrets in the chart.

This is helpful so I don't have to keep those secrets around to run updates to the chart.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
