### PR TITLE
Limit the kiam agent privileges.

### DIFF
--- a/stable/kiam/Chart.yaml
+++ b/stable/kiam/Chart.yaml
@@ -1,5 +1,5 @@
 name: kiam
-version: 2.0.0-rc6
+version: 2.0.0-rc8
 appVersion: 3.0-rc1
 description: Integrate AWS IAM with Kubernetes
 keywords:

--- a/stable/kiam/templates/agent-daemonset.yaml
+++ b/stable/kiam/templates/agent-daemonset.yaml
@@ -58,7 +58,8 @@ spec:
         - name: {{ template "kiam.name" . }}-{{ .Values.agent.name }}
         {{- if .Values.agent.host.iptables }}
           securityContext:
-            privileged: true
+            capabilities:
+              add: ["NET_ADMIN"]
         {{- end }}
           image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag }}"
           imagePullPolicy: {{ .Values.agent.image.pullPolicy }}


### PR DESCRIPTION
<!--
Thank you for contributing to helm/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
Limit the kiam agent privileges.

Port uswitch/kiam#82 to stable/kiam

The agent only needs CAP_NET_ADMIN in order to update the iptables rules that it uses.
As a result, we can remove the full privileged:true and give it a more precise set of capabilities.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://www.helm.sh/blog/helm-dco/index.html) signed
- [X] Chart Version bumped
